### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,0 +1,35 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: master
+
+jobs:
+  push_to_registry:
+    # Remove this after setting up personal access token
+    if: false
+    name: Push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Check out the repo
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          # https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          # We can make this dynamic too, by extracting solidity version from the config.
+          tags: |
+            ghcr.io/chainshot/solidity:0.7.5

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:14-alpine
+
+RUN set -ex; \
+    adduser -D -u 9999 codewarrior; \
+    mkdir /workspace; \
+    chown codewarrior:codewarrior /workspace;
+
+ENV NPM_CONFIG_LOGLEVEL=warn
+COPY --chown=codewarrior:codewarrior package.json /workspace/package.json
+COPY --chown=codewarrior:codewarrior package-lock.json /workspace/package-lock.json
+
+RUN set -ex; \
+    apk add --no-cache --virtual .build-deps \
+# su-exec makes running commands as a different user easy
+        su-exec \
+        bash \
+        build-base \
+        git \
+        python \
+    ; \
+    cd /workspace; \
+    su-exec codewarrior npm install; \
+    apk del --purge .build-deps; \
+    rm -rf /var/cache/apk/* /tmp/* /home/codewarrior/.npm;
+
+USER codewarrior
+COPY --chown=codewarrior:codewarrior . /workspace
+WORKDIR /workspace
+ENV NODE_ENV=production
+RUN set -ex; \
+    npx hardhat compile; \
+    npx hardhat test; \
+    rm contracts/*.sol; \
+    rm test/*.js;

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -11,6 +11,6 @@ module.exports = {
     }
   },
   mocha: {
-    // reporter: require("./mocha-reporter"),
+    reporter: require("@codewars/mocha-reporter"),
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@codewars/mocha-reporter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@codewars/mocha-reporter/-/mocha-reporter-1.0.0.tgz",
+      "integrity": "sha512-L8FIUFqifLbmyQbQQPIDxH2hxRKLZrIZnwBdgBgEkUOARMkuFn/Yngnz1cT9ZErBAif9IIdcVfLyZmXBdBjwBA==",
+      "dev": true
+    },
     "@ensdomains/ens": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/@ensdomains/ens/-/ens-0.4.5.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@codewars/mocha-reporter": "^1.0.0",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
     "chai": "^4.2.0",


### PR DESCRIPTION
We can maintain this repository as a source of Solidity images used by
ChainShot. Renaming and moving under ChainShot org will be nice.

I've added an example GitHub action showing how to build and push to
GitHub Container Registry when pushed to `master`.
The registry can be changed to DockerHub if you have an account there.

You can enable this action by removing `if: false` after creating and
storing personal access token secret. Note that the image name must be
lowercase.